### PR TITLE
Fixes sshuttle command example

### DIFF
--- a/docs/guides/accessing-kubernetes.md
+++ b/docs/guides/accessing-kubernetes.md
@@ -111,7 +111,7 @@
 1. Setup [sshuttle](https://github.com/apenwarr/sshuttle) from your local machine to your KuBOSH Director
 
    ```
-   sshuttle -r <local machine IP address> <KuBOSH Subnet CIDR>
+   sshuttle -r <user@bosh-bastion IP addeess> <KuBOSH Subnet CIDR>
    ```
 
 1. View the Kubernetes dashboard from your browser at `<worker node IP>:<NodePort>`


### PR DESCRIPTION
I don't think the sshuttle example is correct. It should specify the bastion host as a remote server, not the local IP.