### PR TITLE
Add links with same name as community release provides

### DIFF
--- a/manifests/kubo.yml
+++ b/manifests/kubo.yml
@@ -2,9 +2,9 @@ name: ((deployment_name))
 
 releases:
 - name: etcd
-  version: 85+dev.1
-  url: https://s3.amazonaws.com/kubo-public/etcd-85%2Bdev.1.tgz
-  sha1: 3e2aa617afee3ce522effead79c6ab3cf73ec38b
+  version: 100+dev.1
+  url: https://storage.googleapis.com/kubo-public/etcd-100%2Bdev.1.tgz
+  sha1: 9f3625ff778adfaa1b4f72f45ae0dfa049e2590d
 - name: kubo
   version: latest
 - name: docker


### PR DESCRIPTION
[#145163059]
The release has two links to etcd: legacy manually implemented - `etcd` and community driven - `etcd_service`