### PR TITLE
Adding user agent string prefix for google bosh cpi deployment

### DIFF
--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -74,6 +74,7 @@ deploy_gcp() {
     --ops-file "$(repo_directory)/bosh-deployment/powerdns.yml" \
     --ops-file "$(repo_directory)/configurations/generic/credhub.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
+    --ops-file "${current_directory}/configurations/gcp/user-agent-config.yml" \
     --state "${bosh_env}/state.json" \
     --var-file gcp_credentials_json="${service_account_filename}" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/bin/deploy_bosh
+++ b/bin/deploy_bosh
@@ -74,7 +74,7 @@ deploy_gcp() {
     --ops-file "$(repo_directory)/bosh-deployment/powerdns.yml" \
     --ops-file "$(repo_directory)/configurations/generic/credhub.yml" \
     --ops-file "$(repo_directory)/configurations/generic/bosh-admin-client.yml" \
-    --ops-file "${current_directory}/configurations/gcp/user-agent-config.yml" \
+    --ops-file "$(repo_directory)/configurations/gcp/user-agent-config.yml" \
     --state "${bosh_env}/state.json" \
     --var-file gcp_credentials_json="${service_account_filename}" \
     --vars-store "${bosh_env}/creds.yml" \

--- a/configurations/gcp/user-agent-config.yml
+++ b/configurations/gcp/user-agent-config.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /cloud_provider/properties/google/user_agent_prefix?
+  value: "kubo/0.0.3"


### PR DESCRIPTION
This cloud provider property will allow us to see how many people are using kubo on GCP.