### PR TITLE
Update kubo-release URL

### DIFF
--- a/docs/guides/gcp-cf/director.yml.erb
+++ b/docs/guides/gcp-cf/director.yml.erb
@@ -35,7 +35,7 @@ stemcell_url: "https://s3.amazonaws.com/bosh-core-stemcells/google/bosh-stemcell
 syslog-endpoint: ""
 
 credhub_release_url: https://s3.amazonaws.com/kubo-public/credhub-0.4.0.tgz
-kubo_release_url: https://s3.amazonaws.com/kubo-public/kubo-release-latest.tgz
+kubo_release_url: https://storage.googleapis.com/kubo-public/kubo-release-latest.tgz
 
 # CF routing mode settings
 routing_mode: cf

--- a/docs/guides/gcp/director.yml.erb
+++ b/docs/guides/gcp/director.yml.erb
@@ -33,7 +33,7 @@ stemcell_version: "3312.17" # version of the stemcell used in all Kubo deploymen
 stemcell_url: "https://s3.amazonaws.com/bosh-core-stemcells/google/bosh-stemcell-3312.17-google-kvm-ubuntu-trusty-go_agent.tgz" # path to a stemcell used in all Kubo deployments
 
 credhub_release_url: https://s3.amazonaws.com/kubo-public/credhub-0.4.0.tgz
-kubo_release_url: https://s3.amazonaws.com/kubo-public/kubo-release-latest.tgz
+kubo_release_url: https://storage.googleapis.com/kubo-public/kubo-release-latest.tgz
 
 # IaaS routing mode settings
 # Comment this section when using CF routing mode


### PR DESCRIPTION
These did not get updated when we moved our blobstore/release bucket