### PR TITLE
Fix Credhub warning for skip_ssl_verification

### DIFF
--- a/bin/set_kubeconfig
+++ b/bin/set_kubeconfig
@@ -42,7 +42,7 @@ main() {
 
   local director_name credhub_user_password credhub_api_url
   director_name=$(get_setting director.yml "/director_name")
-  credhub_user_password="$(get_setting "creds.yml" "/credhub_user_password")"
+  credhub_user_password=$(get_setting "creds.yml" "/credhub_cli_password")
   credhub_api_url="https://$(get_setting "director.yml" "/internal_ip"):8844"
   tmp_credhub_ca_file="$(mktemp)"
   get_setting "creds.yml" --path=/credhub_tls/ca > "${tmp_credhub_ca_file}"

--- a/bin/set_kubeconfig
+++ b/bin/set_kubeconfig
@@ -43,9 +43,9 @@ main() {
   local director_name credhub_user_password credhub_api_url
   director_name=$(get_setting director.yml "/director_name")
   credhub_user_password=$(get_setting "creds.yml" "/credhub_cli_password")
-  credhub_api_url="https://$(get_setting "director.yml" "/internal_ip"):8844"
+  credhub_api_url="https://$(get_setting director.yml "/internal_ip"):8844"
   tmp_credhub_ca_file="$(mktemp)"
-  get_setting "creds.yml" --path=/credhub_tls/ca > "${tmp_credhub_ca_file}"
+  get_setting creds.yml "/credhub_tls/ca" > "${tmp_credhub_ca_file}"
 
   credhub login -u credhub-cli -p "${credhub_user_password}" -s "${credhub_api_url}" --ca-cert "${tmp_credhub_ca_file}"
 

--- a/bin/set_kubeconfig
+++ b/bin/set_kubeconfig
@@ -45,7 +45,7 @@ main() {
   credhub_user_password="$(get_setting "creds.yml" "/credhub_user_password")"
   credhub_api_url="https://$(get_setting "director.yml" "/internal_ip"):8844"
   tmp_credhub_ca_file="$(mktemp)"
-  bosh-cli int <(credhub get -n "${director_name}/${deployment_name}/tls-kubernetes" --output-json) --path=/credhub_tls/ca > "${tmp_credhub_ca_file}"
+  get_setting "creds.yml" --path=/credhub_tls/ca > "${tmp_credhub_ca_file}"
 
   credhub login -u credhub-cli -p "${credhub_user_password}" -s "${credhub_api_url}" --ca-cert "${tmp_credhub_ca_file}"
 

--- a/bin/set_kubeconfig
+++ b/bin/set_kubeconfig
@@ -44,8 +44,9 @@ main() {
   director_name=$(get_setting director.yml "/director_name")
   credhub_user_password=$(get_setting "creds.yml" "/credhub_cli_password")
   credhub_api_url="https://$(get_setting director.yml "/internal_ip"):8844"
+
   tmp_credhub_ca_file="$(mktemp)"
-  get_setting creds.yml "/credhub_tls/ca" > "${tmp_credhub_ca_file}"
+  bosh-cli int "${bosh_env}/creds.yml" --path="/credhub_tls/ca" > "${tmp_credhub_ca_file}"
 
   credhub login -u credhub-cli -p "${credhub_user_password}" -s "${credhub_api_url}" --ca-cert "${tmp_credhub_ca_file}"
 

--- a/bin/set_kubeconfig
+++ b/bin/set_kubeconfig
@@ -47,7 +47,7 @@ main() {
   tmp_credhub_ca_file="$(mktemp)"
   bosh-cli int <(credhub get -n "${director_name}/${deployment_name}/tls-kubernetes" --output-json) --path=/credhub_tls/ca > "${tmp_credhub_ca_file}"
 
-  credhub login -u credhub-user -p "${credhub_user_password}" -s "${credhub_api_url}" --ca-cert "${tmp_credhub_ca_file}"
+  credhub login -u credhub-cli -p "${credhub_user_password}" -s "${credhub_api_url}" --ca-cert "${tmp_credhub_ca_file}"
 
   tmp_ca_file="$(mktemp)"
   bosh-cli int <(credhub get -n "${director_name}/${deployment_name}/tls-kubernetes" --output-json) --path=/value/ca > "${tmp_ca_file}"

--- a/bin/set_kubeconfig
+++ b/bin/set_kubeconfig
@@ -16,7 +16,7 @@ print_usage() {
 }
 
 repo_directory() {
-  echo -n $(cd "$(dirname ${BASH_SOURCE[0]})/.."; pwd)
+  echo -n "$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 }
 
 main() {
@@ -29,7 +29,7 @@ main() {
     exit  1
   fi
 
-  if [ -z "$(bosh-cli int ${bosh_env}/director.yml --path /iaas)" ]; then
+  if [ -z "$(bosh-cli int "${bosh_env}/director.yml" --path /iaas)" ]; then
    echo "${bosh_env} is not a valid BOSH environment."
    echo "Please use 'generate_env_config' to create one."
    print_usage
@@ -44,8 +44,10 @@ main() {
   director_name=$(get_setting director.yml "/director_name")
   credhub_user_password="$(get_setting "creds.yml" "/credhub_user_password")"
   credhub_api_url="https://$(get_setting "director.yml" "/internal_ip"):8844"
+  tmp_credhub_ca_file="$(mktemp)"
+  bosh-cli int <(credhub get -n "${director_name}/${deployment_name}/tls-kubernetes" --output-json) --path=/credhub_tls/ca > "${tmp_credhub_ca_file}"
 
-  credhub login -u credhub-user -p "${credhub_user_password}" -s "${credhub_api_url}" --skip-tls-validation
+  credhub login -u credhub-user -p "${credhub_user_password}" -s "${credhub_api_url}" --ca-cert "${tmp_credhub_ca_file}"
 
   tmp_ca_file="$(mktemp)"
   bosh-cli int <(credhub get -n "${director_name}/${deployment_name}/tls-kubernetes" --output-json) --path=/value/ca > "${tmp_ca_file}"

--- a/configurations/generic/credhub.yml
+++ b/configurations/generic/credhub.yml
@@ -63,7 +63,7 @@
   value:
     enabled: true
     url: "https://((internal_ip)):8844/api/" # URL must contain /api/ path with trailing slash
-    ca_cert: ((config_server_ssl.ca))
+    ca_cert: ((credhub_tls.ca))
     uaa:
       url: "https://((internal_ip)):8443"
       ca_cert: ((uaa_ssl.ca))
@@ -99,7 +99,7 @@
 - type: replace
   path: /variables/-
   value:
-    name: config_server_ssl
+    name: credhub_tls
     type: certificate
     options:
       ca: default_ca

--- a/configurations/generic/credhub.yml
+++ b/configurations/generic/credhub.yml
@@ -77,8 +77,8 @@
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users/-
   value:
-    name: credhub-user
-    password: ((credhub_user_password))
+    name: credhub-cli
+    password: ((credhub_cli_password))
     groups:
     # Users must have both credhub.read and credhub.write access
     - credhub.read
@@ -93,7 +93,7 @@
 - type: replace
   path: /variables/-
   value:
-    name: credhub_user_password
+    name: credhub_cli_password
     type: password
 
 - type: replace


### PR DESCRIPTION
From ci pipeline https://ci.kubo.sh/teams/main/pipelines/kubo-deployment/jobs/deploy-workload-gcp/builds/24
```
+ credhub login -u credhub-user -p unzqvrjr709qu0erfrmd -s https://10.0.252.252:8844 --skip-tls-validation
Warning: The targeted TLS certificate has not been verified for this connection.
Warning: The --skip-tls-validation flag is deprecated. Please use --ca-cert instead.
Setting the target url: https://10.0.252.252:8844
Login Successful
```

[#145644667]